### PR TITLE
新增選擇器，拖移卡排功能，與修掉重複卡排會重複計算羈絆的問題

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,10 @@
       justify-content: center;
       position: absolute;
       cursor: pointer;
+      user-select: none;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
     }
     .hex img {
       max-width: 100%;
@@ -171,6 +175,20 @@
       (traitMap[name] || []).forEach(t => traitCount[t] = Math.max(0, (traitCount[t] || 0) - 1));
       updateTraitsDisplay();
     }
+    function recalculateTraits() {
+      Object.keys(traitCount).forEach(key => traitCount[key] = 0);
+      const uniqueCardNames = new Set();
+      document.querySelectorAll('.hex img[data-name]').forEach(img => {
+        const cardName = img.dataset.name;
+        if (cardName && traitMap[cardName]) {
+          uniqueCardNames.add(cardName);
+        }
+      });
+      uniqueCardNames.forEach(cardName => {
+        traitMap[cardName].forEach(t => traitCount[t] = (traitCount[t] || 0) + 1);
+      });
+      updateTraitsDisplay();
+    }
 
     function closePopup() {
       if (currentPopup) {
@@ -215,12 +233,11 @@
           e.stopPropagation();
           const existingImg = hex.querySelector("img");
           if (existingImg) {
-            removeTraits(existingImg.dataset.name);
             hex.innerHTML = "";
           }
-          hex.innerHTML = `<img src="images/${name}.png" data-name="${name}" />`;
-          addTraits(name);
+          hex.innerHTML = `<img src="images/${name}.png" data-name="${name}" draggable="true" style="pointer-events: auto;" />`;
           closePopup();
+          setTimeout(recalculateTraits, 10);
         };
         popup.appendChild(card);
       });
@@ -245,35 +262,97 @@
 
         hex.onclick = (event) => {
           event.stopPropagation();
-          
+
           const existingImg = hex.querySelector("img");
           if (existingImg) {
-            removeTraits(existingImg.dataset.name);
             hex.innerHTML = "";
+            setTimeout(recalculateTraits, 10);
             return;
           }
           if (selectedCard) {
-            hex.innerHTML = `<img src="images/${selectedCard}.png" data-name="${selectedCard}" />`;
-            addTraits(selectedCard);
+            hex.innerHTML = `<img src="images/${selectedCard}.png" data-name="${selectedCard}" draggable="true" style="pointer-events: auto;" />`;
             document.querySelectorAll(".card").forEach(c => c.classList.remove("selected"));
             selectedCard = null;
+            setTimeout(recalculateTraits, 10);
           } else {
             showCardPopup(hex, event);
           }
         };
 
-        hex.ondragover = e => e.preventDefault();
+        hex.ondragover = e => {
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'move';
+        };
+        
         hex.ondrop = e => {
           e.preventDefault();
-          const name = e.dataTransfer.getData("card-name");
-          const imgURL = e.dataTransfer.getData("text/plain");
-          if (!hex.querySelector("img")) {
-            hex.innerHTML = `<img src="${imgURL}" data-name="${name}" />`;
-            addTraits(name);
+          
+          const draggedCardName = e.dataTransfer.getData("dragged-card-name");
+          const draggedImgSrc = e.dataTransfer.getData("dragged-img-src");
+          
+          if (draggedCardName && draggedImgSrc) {
+            const existingImg = hex.querySelector("img");
+            
+            const draggedImg = document.querySelector('.hex img[style*="opacity: 0.5"]');
+            const sourceHex = draggedImg ? draggedImg.parentElement : null;
+            
+            if (!existingImg) {
+              hex.innerHTML = `<img src="${draggedImgSrc}" data-name="${draggedCardName}" draggable="true" style="pointer-events: auto;" />`;
+              
+              if (sourceHex) {
+                sourceHex.innerHTML = "";
+              }
+              
+              setTimeout(recalculateTraits, 10);
+            } else {
+              const existingCardName = existingImg.dataset.name;
+              const existingImgSrc = existingImg.src;
+              
+              hex.innerHTML = `<img src="${draggedImgSrc}" data-name="${draggedCardName}" draggable="true" style="pointer-events: auto;" />`;
+              
+              if (sourceHex) {
+                sourceHex.innerHTML = `<img src="${existingImgSrc}" data-name="${existingCardName}" draggable="true" style="pointer-events: auto;" />`;
+              }
+              
+              setTimeout(recalculateTraits, 10);
+            }
+          } else {
+            const cardName = e.dataTransfer.getData("card-name");
+            const imgURL = e.dataTransfer.getData("text/plain");
+            
+            if (cardName && imgURL) {
+              const existingImg = hex.querySelector("img");
+              hex.innerHTML = `<img src="${imgURL}" data-name="${cardName}" draggable="true" style="pointer-events: auto;" />`;
+              setTimeout(recalculateTraits, 10);
+            }
           }
         };
 
         board.appendChild(hex);
+        
+        hex.addEventListener('dragstart', function(e) {
+          if (e.target.tagName === 'IMG' && e.target.dataset.name) {
+            const cardName = e.target.dataset.name;
+            const imgSrc = e.target.src;
+            
+            e.dataTransfer.setData("dragged-card-name", cardName);
+            e.dataTransfer.setData("dragged-img-src", imgSrc);
+            e.dataTransfer.effectAllowed = 'move';
+            e.target.style.opacity = '0.5';
+          }
+        });
+        
+        hex.addEventListener('selectstart', function(e) {
+          e.preventDefault();
+        });
+        
+        hex.addEventListener('dragend', function(e) {
+          document.querySelectorAll('.hex img[style*="opacity: 0.5"]').forEach(img => {
+            img.style.opacity = '1';
+          });
+        });
+        
+
       }
     }
 
@@ -283,6 +362,10 @@
       updateTraitsDisplay();
       closePopup();
     }
+    
+    window.addEventListener('load', function() {
+      setTimeout(recalculateTraits, 100);
+    });
 
     const cardNames = Object.keys(traitMap);
     cardNames.forEach(name => {

--- a/index.html
+++ b/index.html
@@ -86,6 +86,29 @@
       cursor: pointer;
       margin: 4px;
     }
+    .card-popup {
+      position: fixed;
+      background: #2a2f3b;
+      border: 2px solid #4fff4f;
+      border-radius: 8px;
+      padding: 10px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+      max-width: 300px;
+      z-index: 1000;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+    }
+    .card-popup .card {
+      width: 40px;
+      height: 40px;
+      border-radius: 6px;
+    }
+    .card-popup .card:hover {
+      border-color: #4fff4f;
+      transform: scale(1.1);
+      transition: all 0.2s ease;
+    }
   </style>
 </head>
 <body>
@@ -106,6 +129,7 @@
     const rows = 8, cols = 5;
     const hexWidth = 60, hexHeight = 52;
     let selectedCard = null;
+    let currentPopup = null;
 
     const traitMap = {
       archer: ["Clan", "Ranger"],
@@ -148,6 +172,70 @@
       updateTraitsDisplay();
     }
 
+    function closePopup() {
+      if (currentPopup) {
+        currentPopup.remove();
+        currentPopup = null;
+      }
+    }
+
+    function showCardPopup(hex, event) {
+      closePopup();
+      
+      const popup = document.createElement("div");
+      popup.className = "card-popup";
+      
+      const rect = hex.getBoundingClientRect();
+      
+      const hexCenterX = rect.left + rect.width / 2;
+      const windowCenterX = window.innerWidth / 2;
+      
+      let left, top;
+      
+      if (hexCenterX < windowCenterX) {
+        left = rect.left - 320;
+        top = rect.top;
+      } else {
+        left = rect.right + 20;
+        top = rect.top;
+      }
+      
+      if (left < 10) left = 10;
+      if (left + 300 > window.innerWidth) left = window.innerWidth - 310;
+      
+      popup.style.left = `${left}px`;
+      popup.style.top = `${top}px`;
+      
+      const cardNames = Object.keys(traitMap);
+      cardNames.forEach(name => {
+        const card = document.createElement("div");
+        card.classList.add("card");
+        card.innerHTML = `<img src="images/${name}.png" />`;
+        card.onclick = (e) => {
+          e.stopPropagation();
+          const existingImg = hex.querySelector("img");
+          if (existingImg) {
+            removeTraits(existingImg.dataset.name);
+            hex.innerHTML = "";
+          }
+          hex.innerHTML = `<img src="images/${name}.png" data-name="${name}" />`;
+          addTraits(name);
+          closePopup();
+        };
+        popup.appendChild(card);
+      });
+      
+      document.body.appendChild(popup);
+      currentPopup = popup;
+      
+      document.addEventListener('click', function closeHandler(e) {
+        if (!popup.contains(e.target) && !hex.contains(e.target)) {
+          closePopup();
+          document.removeEventListener('click', closeHandler);
+        }
+      });
+    }
+
     for (let y = 0; y < rows; y++) {
       for (let x = 0; x < cols; x++) {
         const hex = document.createElement("div");
@@ -155,7 +243,9 @@
         hex.style.left = `${x * hexWidth + (y % 2 === 0 ? hexWidth / 2 : 0)}px`;
         hex.style.top = `${y * (hexHeight * 0.82)}px`;
 
-        hex.onclick = () => {
+        hex.onclick = (event) => {
+          event.stopPropagation();
+          
           const existingImg = hex.querySelector("img");
           if (existingImg) {
             removeTraits(existingImg.dataset.name);
@@ -167,6 +257,8 @@
             addTraits(selectedCard);
             document.querySelectorAll(".card").forEach(c => c.classList.remove("selected"));
             selectedCard = null;
+          } else {
+            showCardPopup(hex, event);
           }
         };
 
@@ -189,6 +281,7 @@
       document.querySelectorAll(".hex").forEach(hex => hex.innerHTML = "");
       Object.keys(traitCount).forEach(key => traitCount[key] = 0);
       updateTraitsDisplay();
+      closePopup();
     }
 
     const cardNames = Object.keys(traitMap);


### PR DESCRIPTION
新功能：
- 新增選擇器，點擊空的格子會出現選擇器，如下圖，這樣主播就不用滑鼠滾上滾下 <img width="2560" height="1371" alt="image" src="https://github.com/user-attachments/assets/4d721bd7-b1fd-4a2d-a6e2-8cc42de229c0" />
- 拖移卡排功能，可以從下方牌庫拖移卡牌到棋盤上，或是交換棋盤上卡排的位置，如同遊戲內的一樣，如下圖 ![demo](https://github.com/user-attachments/assets/730d6945-694c-40c8-8c11-c84528b2db93)

修理：
- 重複卡排會重複計算羈絆的問題

close #2 